### PR TITLE
Fix Calendar bug when using isFutureDate

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -129,7 +129,7 @@ export default class Calendar extends React.Component {
             }));
 
             if (isFutureDate) {
-                monthIterator.setMonth(monthIterator.getMonth());
+                monthIterator.setMonth(monthIterator.getMonth() + 1);
             } else {
                 monthIterator.setMonth(monthIterator.getMonth() - 1);
             }


### PR DESCRIPTION
@ivanchenko @joewood @rbermudezg  When using isFutureDate, the calender was broken and repeating the same month over and over.
So this commit fixes this problem. 

Before: 
![screenshot_2016-09-27-00-01-57-412 1](https://cloud.githubusercontent.com/assets/6277978/18847493/176dc1aa-8448-11e6-9d69-d191c09a9d36.jpeg)

After:
![screenshot_2016-09-27-00-14-04-764 1](https://cloud.githubusercontent.com/assets/6277978/18847519/30b60e2e-8448-11e6-8255-d5426f094fbe.jpeg)
