### PR TITLE
Add option to change monthHeaderColor

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ All properties are optional
 
 - **`dayInRangeTextColor`** _(string)_ — In range day text color.
 
+- **`monthHeaderColor`** _(string)_ — Calendar month header text color.
+
 ## Support
 
 Email vlm.ivanchenko@gmail.com for support.

--- a/src/Month.js
+++ b/src/Month.js
@@ -22,14 +22,14 @@ export default class Month extends React.Component {
     render() {
         let {
             days, changeSelection, style, monthsLocale,
-            bodyBackColor, bodyTextColor, headerSepColor, width
+            bodyBackColor, bodyTextColor, headerSepColor, width, monthHeaderColor
         } = this.props;
 
         var monthHeader = monthsLocale[days[15].date.getMonth()] + ' ' + days[15].date.getFullYear();
 
         return (
             <View style={[style, {width: width, backgroundColor: bodyBackColor}]}>
-                <Text style={[styles.monthHeader, {color: bodyTextColor}]}>
+                <Text style={[styles.monthHeader, {color: monthHeaderColor || bodyTextColor}]}>
                     {monthHeader}
                 </Text>
                 <View style={styles.monthDays}>


### PR DESCRIPTION
@ivanchenko @rbermudezg  Let users change monthHeaderColor through props.

If there is no monthHeaderColor, then fallback to bodyTextColor.
![img_0022](https://cloud.githubusercontent.com/assets/6277978/19383681/48da7de4-9223-11e6-95bb-c107ae95c4a4.PNG)
