### PR TITLE
Move react and react-native to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "react-component",
     "react-native"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "react": ">=15.0.0",
     "react-native": ">=0.25.0"
   },


### PR DESCRIPTION
When installing this package within a React Native v0.37 project the packager fails to start with hundreds of these warnings:

```
This warning is caused by a @providesModule declaration with the same name across two different files.
jest-haste-map: @providesModule naming collision:
  Duplicate module name: Vibration
  Paths: /Users/me/Projects/react-native-project/node_modules/react-native/Libraries/Vibration/Vibration.js collides with /Users/me/Projects/react-native-project/node_modules/react-native-day-picker/node_modules/react-native/Libraries/Vibration/Vibration.js

This warning is caused by a @providesModule declaration with the same name across two different files.
jest-haste-map: @providesModule naming collision:
  Duplicate module name: WebSocketInterceptor
  Paths: /Users/me/Projects/react-native-project/node_modules/react-native/Libraries/WebSocket/WebSocketInterceptor.js collides with /Users/me/Projects/react-native-project/node_modules/react-native-day-picker/node_modules/react-native/Libraries/WebSocket/WebSocketInterceptor.js

...
```

I think this is because this project's package.json depends on `react` and `react-native` and so those dependencies are installed twice.

Changing to a `peerDependency` stops this from happening.