### PR TITLE
fix missing month when current day is 31

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -117,6 +117,7 @@ export default class Calendar extends React.Component {
 		var {isFutureDate, startFromMonday} = this.props;
 
 		var startUTC = Date.UTC(startDate.getYear(), startDate.getMonth(), startDate.getDate());
+    monthIterator.setDate(1);
 
 		for (var i = 0; i < count; i++) {
 			var month = this.getDates(monthIterator, startFromMonday);


### PR DESCRIPTION
this bug can be reproduced when set the startDate to 31 August, then September will be missed