### PR TITLE
bug fix for month increment - February is going amiss in some cases.

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -131,9 +131,9 @@ export default class Calendar extends React.Component {
 			}));
 
 			if (isFutureDate) {
-				monthIterator.setMonth(monthIterator.getMonth() + 1);
+				monthIterator.setMonth(monthIterator.getMonth() + 1, 1);
 			} else {
-				monthIterator.setMonth(monthIterator.getMonth() - 1);
+				monthIterator.setMonth(monthIterator.getMonth() - 1, 1);
 			}
 		}
 


### PR DESCRIPTION
The month increment decrement operator is buggy and this should help increment the month correctly. 
February as a month doesn't get constructed in some cases when done this way:

```javascript
if (isFutureDate) {
 monthIterator.setMonth(monthIterator.getMonth() + 1);
} else {
 monthIterator.setMonth(monthIterator.getMonth() - 1);
}
```

This should take care of it correctly.
```javascript
if (isFutureDate) {
 monthIterator.setMonth(monthIterator.getMonth() + 1, 1);
} else {
 monthIterator.setMonth(monthIterator.getMonth() - 1, 1);
}
```